### PR TITLE
Add Previous button when taking a quiz (Candidate)

### DIFF
--- a/src/Controller/QuestionInstanceController.php
+++ b/src/Controller/QuestionInstanceController.php
@@ -77,6 +77,12 @@ class QuestionInstanceController extends AbstractController
         $totalQuestions = $this->quizInstanceService->getQuestionsNumber($quizInstanceId);
         $isLastQuestion = $totalQuestions == $questionInstanceIndex;
 
-        return $this->renderer->renderView('candidate-quiz-page.phtml', ['question' => $question[0], 'answer' => $answer, 'questionInstanceIndex' => $questionInstanceIndex, 'isLastQuestion' => $isLastQuestion]);
+        return $this->renderer->renderView('candidate-quiz-page.phtml',
+            [
+                'question' => $question[0],
+                'answer' => $answer,
+                'questionInstanceIndex' => $questionInstanceIndex,
+                'isLastQuestion' => $isLastQuestion,
+            ]);
     }
 }

--- a/src/Controller/QuestionInstanceController.php
+++ b/src/Controller/QuestionInstanceController.php
@@ -83,6 +83,7 @@ class QuestionInstanceController extends AbstractController
                 'answer' => $answer,
                 'questionInstanceIndex' => $questionInstanceIndex,
                 'isLastQuestion' => $isLastQuestion,
-            ]);
+            ]
+        );
     }
 }

--- a/src/views/candidate-quiz-page.phtml
+++ b/src/views/candidate-quiz-page.phtml
@@ -36,7 +36,7 @@ require_once('partials/head.phtml');
                 <textarea name="answer" class="form-control" id="questionResponse" placeholder="<?php echo $answer->getText()?>"></textarea>
             </div>
             <div class="text-center">
-                <?php if($questionInstanceIndex != 1): ?>
+                <?php if((int) $questionInstanceIndex !== 1): ?>
                 <button formmethod="get" formaction="/quiz/question/<?php echo $questionInstanceIndex-1?>" type="submit" class="btn btn-primary">Previous</button> /
                 <?php endif; ?>
                 <?php if(!$isLastQuestion):?>

--- a/src/views/candidate-quiz-page.phtml
+++ b/src/views/candidate-quiz-page.phtml
@@ -36,10 +36,13 @@ require_once('partials/head.phtml');
                 <textarea name="answer" class="form-control" id="questionResponse" placeholder="<?php echo $answer->getText()?>"></textarea>
             </div>
             <div class="text-center">
+                <?php if($questionInstanceIndex != 1): ?>
+                <button formmethod="get" formaction="/quiz/question/<?php echo $questionInstanceIndex-1?>" type="submit" class="btn btn-primary">Previous</button> /
+                <?php endif; ?>
                 <?php if(!$isLastQuestion):?>
                 <button formmethod="post" formaction="/user/answer/<?php echo $answer->getId()?>/<?php echo $questionInstanceIndex?>" type="submit" class="btn btn-primary">Next</button>
                 <?php else: ?>
-                <button formmethod="POST" formaction="/user/answer/<?php echo $answer->getId()?>" type="submit" class="btn btn-primary">Save</button>
+                <button formmethod="post" formaction="/user/answer/<?php echo $answer->getId()?>" type="submit" class="btn btn-primary">Save</button>
                 <?php endif; ?>
             </div>
         </form>


### PR DESCRIPTION
Add "Previous" button when taking a quiz as a candidate.
The button will not appear if we are on the page with the first question of the quiz.