### PR TITLE
Resolve bug: No questions appear in Questions list to Add/Edit Quiz

### DIFF
--- a/src/views/admin-quiz-add.phtml
+++ b/src/views/admin-quiz-add.phtml
@@ -1,4 +1,8 @@
 <?php
+
+use QuizApp\Entity\QuestionTemplate;
+use ReallyOrm\SearchResult\SearchResult;
+
 require_once('partials/head.phtml');
 ?>
 
@@ -37,9 +41,10 @@ require_once('partials/header.phtml');
         <div class="form-group">
             <label for="quizQuestions">Questions</label>
             <select name="questions[]" class="form-control" id="quizQuestions" multiple>
-                <?php /** @var $questions \QuizApp\Entity\QuestionTemplate[] */?>
+                <?php /** @var $questions SearchResult */?>
                 <?php foreach ($questions->getItems() as $question) :?>
-                <option value="<?php echo $question->getId()?>"><?php echo $question->getText()?></option>
+                    <?php /** @var $question QuestionTemplate */ ?>
+                    <option value="<?php echo $question->getId()?>"><?php echo $question->getText()?></option>
                 <?php endforeach;?>
             </select>
         </div>

--- a/src/views/admin-quiz-add.phtml
+++ b/src/views/admin-quiz-add.phtml
@@ -38,7 +38,7 @@ require_once('partials/header.phtml');
             <label for="quizQuestions">Questions</label>
             <select name="questions[]" class="form-control" id="quizQuestions" multiple>
                 <?php /** @var $questions \QuizApp\Entity\QuestionTemplate[] */?>
-                <?php foreach ($questions as $question) :?>
+                <?php foreach ($questions->getItems() as $question) :?>
                 <option value="<?php echo $question->getId()?>"><?php echo $question->getText()?></option>
                 <?php endforeach;?>
             </select>

--- a/src/views/admin-quiz-edit.phtml
+++ b/src/views/admin-quiz-edit.phtml
@@ -38,7 +38,7 @@ require_once('partials/head.phtml');
                 <label for="quizQuestions">Questions</label>
                 <select name="questions[]" class="form-control" id="quizQuestions" multiple>
                     <?php /** @var $questions \QuizApp\Entity\QuestionTemplate[] */?>
-                    <?php foreach ($questions as $question) :?>
+                    <?php foreach ($questions->getItems() as $question) :?>
                         <?php $id = $question->getId(); ?>
                         <option value="<?php echo $id ?>"
                             <?php /** @var $quizQuestions [] */?>

--- a/src/views/admin-quiz-edit.phtml
+++ b/src/views/admin-quiz-edit.phtml
@@ -1,4 +1,8 @@
 <?php
+
+use QuizApp\Entity\QuestionTemplate;
+use ReallyOrm\SearchResult\SearchResult;
+
 require_once('partials/head.phtml');
 ?>
 
@@ -37,8 +41,9 @@ require_once('partials/head.phtml');
             <div class="form-group">
                 <label for="quizQuestions">Questions</label>
                 <select name="questions[]" class="form-control" id="quizQuestions" multiple>
-                    <?php /** @var $questions \QuizApp\Entity\QuestionTemplate[] */?>
+                    <?php /** @var $questions SearchResult */?>
                     <?php foreach ($questions->getItems() as $question) :?>
+                        <?php /** @var $question QuestionTemplate */ ?>
                         <?php $id = $question->getId(); ?>
                         <option value="<?php echo $id ?>"
                             <?php /** @var $quizQuestions [] */?>


### PR DESCRIPTION
The questions did not appear in "Questions" list on Add and Edit Quiz pages after introducing "SearchResult" class.
The bug was fixed by getting the questions as items in phtml, not as instances of SearchResult.

This PR resolves the following Jira tickets:
PHPTRAININ-517
PHPTRAININ-518