### PR TITLE
Mark quiz as complete

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -939,12 +939,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/andreiuta97/reallyOrm.git",
-                "reference": "086687e184e55cda7603867b463e9a65e728017b"
+                "reference": "b762d119252ce0545337916714f8d7a240e0a73e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/andreiuta97/reallyOrm/zipball/086687e184e55cda7603867b463e9a65e728017b",
-                "reference": "086687e184e55cda7603867b463e9a65e728017b",
+                "url": "https://api.github.com/repos/andreiuta97/reallyOrm/zipball/b762d119252ce0545337916714f8d7a240e0a73e",
+                "reference": "b762d119252ce0545337916714f8d7a240e0a73e",
                 "shasum": ""
             },
             "require": {
@@ -971,7 +971,7 @@
                 "source": "https://github.com/andreiuta97/reallyOrm/tree/master",
                 "issues": "https://github.com/andreiuta97/reallyOrm/issues"
             },
-            "time": "2020-04-08T16:47:22+00:00"
+            "time": "2020-04-14T09:25:24+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/config/config.php
+++ b/config/config.php
@@ -199,6 +199,12 @@ return [
                 Router::CONFIG_KEY_CONTROLLER => 'quizInstance',
                 Router::CONFIG_KEY_ACTION => 'showOverview',
             ],
+            'complete_quiz' => [
+                Router::CONFIG_KEY_METHOD => 'POST',
+                Router::CONFIG_KEY_PATH => '/candidate/overview',
+                Router::CONFIG_KEY_CONTROLLER => 'quizInstance',
+                Router::CONFIG_KEY_ACTION => 'markQuizComplete',
+            ],
             'get_success_page' => [
                 Router::CONFIG_KEY_METHOD => 'GET',
                 Router::CONFIG_KEY_PATH => '/candidate/success',

--- a/src/Controller/QuizInstanceController.php
+++ b/src/Controller/QuizInstanceController.php
@@ -23,7 +23,7 @@ use ReallyOrm\Repository\RepositoryManagerInterface;
 class QuizInstanceController extends AbstractController
 {
     use CriteriaTrait;
-  
+
     private const QUIZ_INSTANCE_ID = 'quiz_instance_id';
 
     /**
@@ -64,7 +64,8 @@ class QuizInstanceController extends AbstractController
         QuestionInstanceService $questionInstanceService,
         Session $session,
         int $resultsPerPage
-    ) {
+    )
+    {
         parent::__construct($renderer);
         $this->repositoryManager = $repositoryManager;
         $this->quizInstanceService = $quizInstanceService;
@@ -125,7 +126,22 @@ class QuizInstanceController extends AbstractController
     }
 
     /**
-     * Displays the 'Congrats' page after completing and saving a quiz.
+     * Marks a quiz as complete and redirects to 'Congrats' page.
+     *
+     * @param Request $request
+     * @param array $requestAttributes
+     * @return Response
+     */
+    public function markQuizComplete(Request $request, array $requestAttributes): Response
+    {
+        $quizInstanceId = $this->session->get(self::QUIZ_INSTANCE_ID);
+        $this->quizInstanceService->markQuizComplete($quizInstanceId, true);
+
+        return $this->createRedirectResponse('/candidate/success');
+    }
+
+    /**
+     * Displays the 'Congrats' page.
      *
      * @param Request $request
      * @param array $requestAttributes

--- a/src/Controller/QuizInstanceController.php
+++ b/src/Controller/QuizInstanceController.php
@@ -135,7 +135,7 @@ class QuizInstanceController extends AbstractController
     public function markQuizComplete(Request $request, array $requestAttributes): Response
     {
         $quizInstanceId = $this->session->get(self::QUIZ_INSTANCE_ID);
-        $this->quizInstanceService->markQuizComplete($quizInstanceId, true);
+        $this->quizInstanceService->markQuiz($quizInstanceId, true);
 
         return $this->createRedirectResponse('/candidate/success');
     }

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -66,13 +66,13 @@ class ResultController extends AbstractController
         $this->resultsPerPage = $resultsPerPage;
     }
 
-    private function criteriaForResults(array $requestAttributes):Criteria
+    private function createCriteriaForResults(array $requestAttributes): Criteria
     {
         if (empty($requestAttributes)) {
             $filters = [];
         }
         foreach ($requestAttributes as $key => $value) {
-            if ($key !== 'page' && $key !== 'order' && $key !== 'orderBy') {
+            if (!in_array($key, ['page', 'order', 'orderBy'], true)) {
                 $filters = isset($requestAttributes[$key]) ? [$key => $requestAttributes[$key]] : [];
             }
         }
@@ -92,7 +92,7 @@ class ResultController extends AbstractController
     public function getResults(Request $request, array $requestAttributes): Response
     {
         $currentPage = $requestAttributes['page'] ?? 1;
-        $criteria = $this->criteriaForResults($requestAttributes);
+        $criteria = $this->createCriteriaForResults($requestAttributes);
         $results = $this->quizInstanceService->getResultsData($criteria);
         $paginator = new Paginator($this->quizInstanceService->getResultsNumber($criteria), $currentPage, $this->resultsPerPage);
 

--- a/src/Entity/QuizInstance.php
+++ b/src/Entity/QuizInstance.php
@@ -40,6 +40,12 @@ class QuizInstance extends AbstractEntity
     private $quizTemplateId;
 
     /**
+     * @ORM is_completed
+     * @var bool
+     */
+    private $isCompleted;
+
+    /**
      * @return int
      */
     public function getId(): int
@@ -88,6 +94,14 @@ class QuizInstance extends AbstractEntity
     }
 
     /**
+     * @return bool
+     */
+    public function isCompleted(): bool
+    {
+        return $this->isCompleted;
+    }
+
+    /**
      * @param string $name
      */
     public function setName(string $name): void
@@ -125,5 +139,13 @@ class QuizInstance extends AbstractEntity
     public function setQuizTemplateId(int $quizTemplateId): void
     {
         $this->quizTemplateId = $quizTemplateId;
+    }
+
+    /**
+     * @param bool $isCompleted
+     */
+    public function setIsCompleted(bool $isCompleted): void
+    {
+        $this->isCompleted = $isCompleted;
     }
 }

--- a/src/Service/AnswerInstanceService.php
+++ b/src/Service/AnswerInstanceService.php
@@ -27,6 +27,6 @@ class AnswerInstanceService
         $answer = $this->answerInstanceRepo->find($id);
         $answer->setText($text);
 
-        $this->answerInstanceRepo->insertOnDuplicateKeyUpdate($answer);
+        $answer->save();
     }
 }

--- a/src/Service/CriteriaTrait.php
+++ b/src/Service/CriteriaTrait.php
@@ -21,7 +21,7 @@ trait CriteriaTrait
             $filters = [];
         }
         foreach ($requestAttributes as $key => $value) {
-            if ($key !== 'page' && $key !== 'order' && $key !== 'orderBy') {
+            if (!in_array($key, ['page', 'order', 'orderBy'], true)) {
                 $filters = isset($requestAttributes[$key]) ? [$key => $requestAttributes[$key]] : [];
             }
         }

--- a/src/Service/QuestionInstanceService.php
+++ b/src/Service/QuestionInstanceService.php
@@ -85,13 +85,13 @@ class QuestionInstanceService
             $question->setType($questionTemplate->getType());
             $question->setQuestionTemplateId($questionTemplate->getId());
             $question->setQuizInstanceId($quizInstance->getId());
-            $this->questionInstanceRepo->insertOnDuplicateKeyUpdate($question);
+            $question->save();
 
             $answerTemplate = $answerTemplateRepo->findOneBy([self::QUESTION_TEMPLATE_ID => $questionTemplate->getId()]);
             $answer = new AnswerInstance();
             $answer->setText($answerTemplate->getText());
             $answer->setQuestionInstanceId($question->getId());
-            $this->answerInstanceRepo->insertOnDuplicateKeyUpdate($answer);
+            $answer->save();
         }
     }
 

--- a/src/Service/QuizInstanceService.php
+++ b/src/Service/QuizInstanceService.php
@@ -135,7 +135,7 @@ class QuizInstanceService
      * @param int $quizInstanceId
      * @param bool $isComplete
      */
-    public function markQuizComplete(int $quizInstanceId, bool $isComplete): void
+    public function markQuiz(int $quizInstanceId, bool $isComplete): void
     {
         /** @var $quizInstance QuizInstance */
         $quizInstance = $this->quizInstanceRepo->find($quizInstanceId);

--- a/src/Service/QuizInstanceService.php
+++ b/src/Service/QuizInstanceService.php
@@ -141,7 +141,7 @@ class QuizInstanceService
         $quizInstance = $this->quizInstanceRepo->find($quizInstanceId);
         $quizInstance->setIsCompleted($isComplete);
 
-        $this->quizInstanceRepo->insertOnDuplicateKeyUpdate($quizInstance);
+        $quizInstance->save();
     }
 
     /**
@@ -150,12 +150,12 @@ class QuizInstanceService
      * @param int $quizInstanceId
      * @param int $score
      */
-    public function saveScore(int $quizInstanceId, int $score):void
+    public function saveScore(int $quizInstanceId, int $score): void
     {
         /** @var $quizInstance QuizInstance */
         $quizInstance = $this->quizInstanceRepo->find($quizInstanceId);
         $quizInstance->setScore($score);
 
-        $this->quizInstanceRepo->insertOnDuplicateKeyUpdate($quizInstance);
+        $quizInstance->save();
     }
 }

--- a/src/Service/QuizInstanceService.php
+++ b/src/Service/QuizInstanceService.php
@@ -60,6 +60,7 @@ class QuizInstanceService
         $quiz->setScore(0);
         $quiz->setUserId($userId);
         $quiz->setQuizTemplateId($quizTemplateId);
+        $quiz->setIsCompleted(false);
         $this->quizInstanceRepo->insertOnDuplicateKeyUpdate($quiz);
         $this->session->set('quiz_instance_id', $quiz->getId());
 
@@ -129,12 +130,27 @@ class QuizInstanceService
     }
 
     /**
+     * Marks the completion of a quiz in the database.
+     *
+     * @param int $quizInstanceId
+     * @param bool $isComplete
+     */
+    public function markQuizComplete(int $quizInstanceId, bool $isComplete): void
+    {
+        /** @var $quizInstance QuizInstance */
+        $quizInstance = $this->quizInstanceRepo->find($quizInstanceId);
+        $quizInstance->setIsCompleted($isComplete);
+
+        $this->quizInstanceRepo->insertOnDuplicateKeyUpdate($quizInstance);
+    }
+
+    /**
      * Saves given score to the database.
      *
      * @param int $quizInstanceId
      * @param int $score
      */
-    public function saveScore(int $quizInstanceId, int $score)
+    public function saveScore(int $quizInstanceId, int $score):void
     {
         /** @var $quizInstance QuizInstance */
         $quizInstance = $this->quizInstanceRepo->find($quizInstanceId);

--- a/src/views/candidate-overview.phtml
+++ b/src/views/candidate-overview.phtml
@@ -1,6 +1,6 @@
 <?php
 
-use QuizApp\Service\AnsweredQuestion;
+use QuizApp\ViewModel\AnsweredQuestion;
 
 require_once('partials/head.phtml');
 ?>
@@ -45,7 +45,7 @@ require_once('partials/header.phtml');
     <?php endforeach; ?>
 
     <!--Results form-->
-    <form action="/candidate/success" method="get">
+    <form action="" method="post">
         <div class="text-center">
             <button type="submit" class="btn btn-primary">Save</button>
         </div>


### PR DESCRIPTION
Introduce a new column in quiz_instance table, "is_completed".
When creating a new quiz instance, this field is set to false.
When a quiz is finished, the field is set to true.
PHPTRAININ-412: https://jira.evozon.com/browse/PHPTRAININ-412

Display only the completed quizzes on "Results Listing" page.
PHPTRAININ-560: https://jira.evozon.com/browse/PHPTRAININ-560
